### PR TITLE
disable centrify group cache rebuild functionality 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class centrify (
   Integer          $adclient_zone_group_count       = $centrify::params::adclient_zone_group_count,
   Integer          $adclient_clients_threads        = $centrify::params::adclient_clients_threads,
   Integer          $adclient_cache_flush_interval   = $centrify::params::adclient_cache_flush_interval,
+  String $adclient_cache_group_membership_visible_check = 'true',
   ) inherits centrify::params {
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class centrify (
   Integer          $adclient_zone_group_count       = $centrify::params::adclient_zone_group_count,
   Integer          $adclient_clients_threads        = $centrify::params::adclient_clients_threads,
   Integer          $adclient_cache_flush_interval   = $centrify::params::adclient_cache_flush_interval,
-  String $adclient_cache_group_membership_visible_check = 'true',
+  Boolean          $adclient_group_membership_check = $centrify::params::adclient_group_membership_check,
   ) inherits centrify::params {
 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,4 +36,5 @@ class centrify::params {
       $adclient_zone_group_count       = 5000
       $adclient_clients_threads        = 2
       $adclient_cache_flush_interval   = 1200
+      $adclient_group_membership_check = false
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,7 @@ class centrify::params {
       $adclient_paged_search_max       = 500
       $adclient_ldap_timeout           = 30
       $adclient_zone_group_count       = 5000
-      $adclient_clients_threads        = 2
+      $adclient_clients_threads        = 20
       $adclient_cache_flush_interval   = 1200
       $adclient_group_membership_check = false
 }

--- a/templates/centrifydc.conf.erb
+++ b/templates/centrifydc.conf.erb
@@ -15,7 +15,7 @@ adclient.ldap.timeout: <%= @adclient_ldap_timeout %>
 adclient.zone.group.count: <%= @adclient_zone_group_count %>
 adclient.clients.threads: <%= @adclient_clients_threads %>
 adclient.cache.flush.interval: <%= @adclient_cache_flush_interval %>
-adclient.cache.group.membership.visible.check: <% @adclient_cache_group_membership_visible_check %>
+adclient.cache.group.membership.visible.check: <% @adclient_group_membership_check %>
 
 nss.nobody.user: nobody
 nss.nobody.group: nobody

--- a/templates/centrifydc.conf.erb
+++ b/templates/centrifydc.conf.erb
@@ -15,6 +15,7 @@ adclient.ldap.timeout: <%= @adclient_ldap_timeout %>
 adclient.zone.group.count: <%= @adclient_zone_group_count %>
 adclient.clients.threads: <%= @adclient_clients_threads %>
 adclient.cache.flush.interval: <%= @adclient_cache_flush_interval %>
+adclient.cache.group.membership.visible.check: <% @adclient_cache_group_membership_visible_check %>
 
 nss.nobody.user: nobody
 nss.nobody.group: nobody


### PR DESCRIPTION
This is one of the options recommended by Centrify folks